### PR TITLE
HPC fix April 2016

### DIFF
--- a/dtu-hpc-python3/README.md
+++ b/dtu-hpc-python3/README.md
@@ -4,11 +4,11 @@ Install python and friends on DTUs shared user system. Included is:
 
 * numpy
 * scipy
-* matplotlib (with Qt4 and basemap)
+* matplotlib (with Qt5 and basemap)
 * scikit-learn
 * pandas
 * PyOpenCL (with mako)
-* Theano (with pydot, clBLAS, libgpuarray)
+* Theano (with pydot and libgpuarray)
 * netCDF4
 
 ### Run setup script
@@ -32,9 +32,9 @@ For any future login and after the installation run one of these:
 ```shell
 k40sh
 module load python3
-module load gcc
+module load gcc/4.9.2
+module load cuda/7.0
 module load qt
-module load cuda
 export PYTHONPATH=
 source ~/stdpy3/bin/activate
 ```
@@ -44,7 +44,7 @@ source ~/stdpy3/bin/activate
 ```shell
 qrsh
 module load python3
-module load gcc
+module load gcc/4.9.2
 module load qt
 export PYTHONPATH=
 source ~/stdpy3/bin/activate
@@ -54,7 +54,7 @@ You can make this happen automatically for all shell-login, just run:
 
 ```shell
 cat >> .gbarrc <<EOF
-MODULES=python3,gcc,qt,cuda
+MODULES=python3,gcc/4.9.2,qt,cuda/7.0
 EOF
 cat >> .profile <<EOF
 # Setup local python3

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -73,7 +73,7 @@ wgetretry http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.5.1/PyQt-gpl-5
 tar -xf PyQt-gpl-5.5.1.tar.gz
 cd PyQt-gpl-5.5.1
 python3 configure.py --confirm-license
-make
+make -j4
 make install
 cd $HOME
 rm -rf PyQt-gpl-5.5.1*

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -75,8 +75,36 @@ wgetretry http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.5.1/PyQt-gpl-5
 tar -xf PyQt-gpl-5.5.1.tar.gz
 cd PyQt-gpl-5.5.1
 python3 configure.py --confirm-license
+# For some unknow reason the qt5 designer installs in the wrong path,
+# fortunately it isn't needed so just remove the install target
+patch -f designer/Makefile \
+<<EOF
+--- designer/Makefile
++++ designer/Makefile
+@@ -1694,7 +1694,7 @@
+ 	-$(DEL_DIR) $(INSTALL_ROOT)/appl/qt/5.5.0/plugins/designer/
+
+
+-install: install_target  FORCE
++install: FORCE
+
+ uninstall: uninstall_target  FORCE
+EOF
+patch -f qmlscene/Makefile \
+<<EOF
+--- qmlscene/Makefile
++++ qmlscene/Makefile
+@@ -829,7 +829,7 @@
+ 	-$(DEL_DIR) $(INSTALL_ROOT)/appl/qt/5.5.0/plugins/PyQt5/
+
+
+-install: install_target  FORCE
++install: FORCE
+
+ uninstall: uninstall_target  FORCE
+EOF
 make -j4
-make install DESTDIR=$HOME INSTALL_ROOT=$HOME
+make install
 cd $HOME
 rm -rf PyQt-gpl-5.5.1*
 

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -23,10 +23,12 @@ function wgetretry {
 }
 
 # Load already installed software
-module load python3
 module unload gcc
+module unload cuda
+
+module load python3
 module load gcc/4.9.2
-module load cuda
+module load cuda/7.0
 module load qt
 module load boost
 
@@ -34,8 +36,8 @@ module load boost
 export CC='gcc -w'
 export CXX='g++ -w'
 
-# Setup cuda path for clBLAS
-export CUDA_PATH=/opt/cuda/6.5
+# Setup cuda path for theano
+export CUDA_PATH='/appl/cuda/7.0'
 
 # Expand path
 export PATH="$HOME/bin:$PATH"
@@ -162,11 +164,12 @@ make install
 cd $HOME
 rm -rf cmake-3.5.1*
 
-# Install libgpuarray (optional theano dependencies)
+# Install libgpuarray (optional theano dependency)
 # Note the HPC version of check.h is old, so ck_assert_ptr_ne is not defined
 # since it is just the test files. Just remove the test.
 git clone https://github.com/Theano/libgpuarray.git
 cd libgpuarray
+git checkout 99a51ba43bb05eb2c6f848439867dce0f05fca5f
 patch -f tests/check_array.c \
 <<EOF
 --- check_array.c
@@ -177,57 +180,48 @@ patch -f tests/check_array.c \
    ctx = ops->buffer_init(dev, 0, NULL);
 -  ck_assert_ptr_ne(ctx, NULL);
  }
+
  void teardown(void) {
 EOF
 patch -f tests/check_util.c \
 <<EOF
 --- check_util.c
 +++ check_util.c
-@@ -60,8 +60,8 @@
+@@ -60,8 +60,6 @@
    strs[1][2] = 4;
 
    gpuarray_elemwise_collapse(2, &nd, dims, strs);
 -  ck_assert_uint_eq(nd, 1);
 -  ck_assert_uint_eq(dims[0], 1000);
-+  //ck_assert_uint_eq(nd, 1);
-+  //ck_assert_uint_eq(dims[0], 1000);
    ck_assert_int_eq(strs[0][0], 4);
    ck_assert_int_eq(strs[1][0], 4);
 
-@@ -77,9 +77,9 @@
+@@ -77,9 +75,6 @@
    strs[1][2] = 4;
 
    gpuarray_elemwise_collapse(2, &nd, dims, strs);
 -  ck_assert_uint_eq(nd, 2);
 -  ck_assert_uint_eq(dims[0], 50);
 -  ck_assert_uint_eq(dims[1], 20);
-+  //ck_assert_uint_eq(nd, 2);
-+  //ck_assert_uint_eq(dims[0], 50);
-+  //ck_assert_uint_eq(dims[1], 20);
    ck_assert_int_eq(strs[0][0], 168);
    ck_assert_int_eq(strs[0][1], 4);
    ck_assert_int_eq(strs[1][0], 80);
-@@ -97,9 +97,9 @@
+@@ -97,9 +92,6 @@
    strs[1][2] = 80;
 
    gpuarray_elemwise_collapse(2, &nd, dims, strs);
 -  ck_assert_uint_eq(nd, 2);
 -  ck_assert_uint_eq(dims[0], 20);
 -  ck_assert_uint_eq(dims[1], 50);
-+  //ck_assert_uint_eq(nd, 2);
-+  //ck_assert_uint_eq(dims[0], 20);
-+  //ck_assert_uint_eq(dims[1], 50);
    ck_assert_int_eq(strs[0][0], 4);
    ck_assert_int_eq(strs[0][1], 168);
    ck_assert_int_eq(strs[1][0], 4);
-@@ -112,8 +112,8 @@
+@@ -112,8 +104,6 @@
    strs[0][1] = 4;
 
    gpuarray_elemwise_collapse(1, &nd, dims, strs);
 -  ck_assert_uint_eq(nd, 1);
 -  ck_assert_uint_eq(dims[0], 1);
-+  //ck_assert_uint_eq(nd, 1);
-+  //ck_assert_uint_eq(dims[0], 1);
    ck_assert_int_eq(strs[0][0], 4);
  }
  END_TEST

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -257,8 +257,8 @@ pip3 install git+https://github.com/Lasagne/Lasagne.git
 #
 
 # Install HDF5 (netCDF4 dependency)
-wgetretry http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar
-tar -xf hdf5-1.8.16.tar
+wgetretry http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar.gz
+tar -xf hdf5-1.8.16.tar.gz
 cd hdf5-1.8.16
 ./configure --prefix=$HOME --enable-shared --enable-hl
 make -j4
@@ -272,7 +272,7 @@ pip3 install h5py
 
 # Install netCDF4 (netCDF4-python dependency)
 wgetretry ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.0.tar.gz
-tar -xzf netcdf-4.4.0.tar.gz
+tar -xf netcdf-4.4.0.tar.gz
 cd netcdf-4.4.0
 ./configure --enable-netcdf-4 --enable-dap --enable-shared --prefix=$HOME
 make -j4

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -57,10 +57,10 @@ pip3 install -U numpy
 pip3 install -U scipy
 
 #
-# Install matplotlib with Qt4 and basemap enabled
+# Install matplotlib with Qt5 and basemap enabled
 #
 
-# Install sip (dependency for PyQt4)
+# Install sip (dependency for PyQt5)
 wgetretry http://sourceforge.net/projects/pyqt/files/sip/sip-4.17/sip-4.17.tar.gz
 tar -xf sip-4.17.tar.gz
 cd sip-4.17

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -2,9 +2,10 @@
 
 #PBS -N setup-python3
 #PBS -l walltime=01:30:00
-#PBS -l nodes=1:ppn=1:gpus=1
+#PBS -l nodes=1:ppn=4:gpus=1
 #PBS -j oe
 #PBS -o setup-python3.log
+#PBS -q k40_interactive
 
 # Stop on error
 set -e
@@ -23,7 +24,8 @@ function wgetretry {
 
 # Load already installed software
 module load python3
-module load gcc
+module unload gcc
+module load gcc/4.9.2
 module load cuda
 module load qt
 module load boost
@@ -33,7 +35,10 @@ export CC='gcc -w'
 export CXX='g++ -w'
 
 # Setup cuda path for clBLAS
-export CUDA_PATH=/opt/cuda/current
+export CUDA_PATH=/opt/cuda/6.5
+
+# Expand path
+export PATH="$HOME/bin:$PATH"
 
 # Use HOME directory as base
 cd $HOME
@@ -54,35 +59,35 @@ pip3 install -U scipy
 #
 
 # Install sip (dependency for PyQt4)
-wgetretry http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.6/sip-4.16.6.zip
-unzip -q sip-4.16.6.zip
-cd sip-4.16.6
+wgetretry http://sourceforge.net/projects/pyqt/files/sip/sip-4.17/sip-4.17.tar.gz
+tar -xf sip-4.17.tar.gz
+cd sip-4.17
 python3 configure.py
-make
+make -j4
 make install
 cd $HOME
-rm -rf sip-4.16.6*
+rm -rf sip-4.17*
 
-# Install PyQt4 (optional backend for matplotlib)
-wgetretry http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.3/PyQt-x11-gpl-4.11.3.tar.gz
-tar -xf PyQt-x11-gpl-4.11.3.tar.gz
-cd PyQt-x11-gpl-4.11.3
+# Install PyQt5 (optional backend for matplotlib)
+wgetretry http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.5.1/PyQt-gpl-5.5.1.tar.gz
+tar -xf PyQt-gpl-5.5.1.tar.gz
+cd PyQt-gpl-5.5.1
 python3 configure.py --confirm-license
 make
 make install
 cd $HOME
-rm -rf PyQt-x11-gpl-4.11.3*
+rm -rf PyQt-gpl-5.5.1*
 
 # Install matplotlib
 pip3 install -U matplotlib
 
 # Install basemap (matplotlib extension)
 wgetretry http://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz
-tar -xf basemap-1.0.7.tar.gz 
+tar -xf basemap-1.0.7.tar.gz
 cd basemap-1.0.7
 cd geos-3.3.3
 ./configure --prefix=$HOME
-make
+make -j4
 make install
 cd ..
 python3 setup.py install
@@ -102,17 +107,26 @@ pip3 install -U pandas
 # Install mako (optional dependency for pyopencl)
 pip3 install -U mako
 
+# Install ctags
+wgetretry http://prdownloads.sourceforge.net/ctags/ctags-5.8.tar.gz
+tar -xf ctags-5.8.tar.gz
+cd ctags-5.8
+./configure --prefix=$HOME
+make -j4 install
+cd $HOME
+rm -rf ctags-5.8*
+
 # Install pyOpenCL
-wgetretry https://pypi.python.org/packages/source/p/pyopencl/pyopencl-2015.1.tar.gz
-tar -xf pyopencl-2015.1.tar.gz
-cd pyopencl-2015.1
+wgetretry https://pypi.python.org/packages/source/p/pyopencl/pyopencl-2015.2.4.tar.gz
+tar -xf pyopencl-2015.2.4.tar.gz
+cd pyopencl-2015.2.4
 python3 configure.py \
     --cl-inc-dir=$CUDA_PATH/include \
     --cl-lib-dir=$CUDA_PATH/lib \
     --cl-libname=OpenCL
-make install
+make -j4 install
 cd $HOME
-rm -rf pyopencl-2015.1*
+rm -rf pyopencl-2015.2.4*
 
 #
 # Install theano
@@ -120,6 +134,8 @@ rm -rf pyopencl-2015.1*
 
 # Instal pydot (optional theano dependencies)
 pip3 install https://bitbucket.org/prologic/pydot/get/ac76697320d6.zip
+pip3 uninstall -y pyparsing
+pip3 install -U pyparsing==2.0.6
 patch -f stdpy3/lib/python3.4/site-packages/dot_parser.py \
 <<EOF
 --- a/stdpy3/lib/python3.4/site-packages/dot_parser.py
@@ -136,6 +152,16 @@ patch -f stdpy3/lib/python3.4/site-packages/dot_parser.py \
  class P_AttrList:
 EOF
 
+# Upgrade cmake
+wgetretry https://cmake.org/files/v3.5/cmake-3.5.1.tar.gz
+tar -xf cmake-3.5.1.tar.gz
+cd cmake-3.5.1
+./bootstrap --prefix=$HOME
+make -j4
+make install
+cd $HOME
+rm -rf cmake-3.5.1*
+
 # Install libgpuarray (optional theano dependencies)
 # Note the HPC version of check.h is old, so ck_assert_ptr_ne is not defined
 # since it is just the test files. Just remove the test.
@@ -151,27 +177,79 @@ patch -f tests/check_array.c \
    ctx = ops->buffer_init(dev, 0, NULL);
 -  ck_assert_ptr_ne(ctx, NULL);
  }
-
  void teardown(void) {
+EOF
+patch -f tests/check_util.c \
+<<EOF
+--- check_util.c
++++ check_util.c
+@@ -60,8 +60,8 @@
+   strs[1][2] = 4;
+
+   gpuarray_elemwise_collapse(2, &nd, dims, strs);
+-  ck_assert_uint_eq(nd, 1);
+-  ck_assert_uint_eq(dims[0], 1000);
++  //ck_assert_uint_eq(nd, 1);
++  //ck_assert_uint_eq(dims[0], 1000);
+   ck_assert_int_eq(strs[0][0], 4);
+   ck_assert_int_eq(strs[1][0], 4);
+
+@@ -77,9 +77,9 @@
+   strs[1][2] = 4;
+
+   gpuarray_elemwise_collapse(2, &nd, dims, strs);
+-  ck_assert_uint_eq(nd, 2);
+-  ck_assert_uint_eq(dims[0], 50);
+-  ck_assert_uint_eq(dims[1], 20);
++  //ck_assert_uint_eq(nd, 2);
++  //ck_assert_uint_eq(dims[0], 50);
++  //ck_assert_uint_eq(dims[1], 20);
+   ck_assert_int_eq(strs[0][0], 168);
+   ck_assert_int_eq(strs[0][1], 4);
+   ck_assert_int_eq(strs[1][0], 80);
+@@ -97,9 +97,9 @@
+   strs[1][2] = 80;
+
+   gpuarray_elemwise_collapse(2, &nd, dims, strs);
+-  ck_assert_uint_eq(nd, 2);
+-  ck_assert_uint_eq(dims[0], 20);
+-  ck_assert_uint_eq(dims[1], 50);
++  //ck_assert_uint_eq(nd, 2);
++  //ck_assert_uint_eq(dims[0], 20);
++  //ck_assert_uint_eq(dims[1], 50);
+   ck_assert_int_eq(strs[0][0], 4);
+   ck_assert_int_eq(strs[0][1], 168);
+   ck_assert_int_eq(strs[1][0], 4);
+@@ -112,8 +112,8 @@
+   strs[0][1] = 4;
+
+   gpuarray_elemwise_collapse(1, &nd, dims, strs);
+-  ck_assert_uint_eq(nd, 1);
+-  ck_assert_uint_eq(dims[0], 1);
++  //ck_assert_uint_eq(nd, 1);
++  //ck_assert_uint_eq(dims[0], 1);
+   ck_assert_int_eq(strs[0][0], 4);
+ }
+ END_TEST
 EOF
 mkdir Build && cd Build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=~/
-make
+make -j4
 make install
 cd $HOME
 rm -rf libgpuarray
 
 # Install theano
-pip3 install theano
+pip3 install git+https://github.com/Theano/Theano.git
 
-# Configure theano 
+# Configure theano
 cat > .theanorc <<EOF
 [global]
 device = gpu
 floatX = float32
 
 [cuda]
-root = /opt/cuda/current
+root = $CUDA_PATH
 
 [nvcc]
 flags = -arch=sm_30
@@ -184,29 +262,29 @@ pip3 install git+https://github.com/Lasagne/Lasagne.git
 # Install h5py and netCDF4-python
 #
 
-# Install HDF5 (netCDF4 dependency) 
-wgetretry http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.15-patch1.tar.gz
-tar -xf hdf5-1.8.15-patch1.tar.gz
-cd hdf5-1.8.15-patch1
+# Install HDF5 (netCDF4 dependency)
+wgetretry http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar
+tar -xf hdf5-1.8.16.tar
+cd hdf5-1.8.16
 ./configure --prefix=$HOME --enable-shared --enable-hl
-make
+make -j4
 make install
 cd $HOME
-rm -rf hdf5-1.8.15-patch1*
+rm -rf hdf5-1.8.16*
 
 # Install h5py
 pip3 install Cython
 pip3 install h5py
 
-# Install netCDF4 (netCDF4-python dependency) 
-wgetretry ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz
-tar -xzf netcdf-4.3.3.1.tar.gz
-cd netcdf-4.3.3.1
+# Install netCDF4 (netCDF4-python dependency)
+wgetretry ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.0.tar.gz
+tar -xzf netcdf-4.4.0.tar.gz
+cd netcdf-4.4.0
 ./configure --enable-netcdf-4 --enable-dap --enable-shared --prefix=$HOME
-make
+make -j4
 make install
 cd $HOME
-rm -rf netcdf-4.3.3.1*
+rm -rf netcdf-4.4.0*
 
 # Install netCDF4-python
 pip3 install netcdf4
@@ -215,7 +293,7 @@ pip3 install netcdf4
 cat <<EOF
 ####################################
 ##                                ##
-##       python3 installed        ## 
+##       python3 installed        ##
 ##                                ##
 ####################################
 EOF

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -299,14 +299,14 @@ pip3 install Cython
 pip3 install h5py
 
 # Install netCDF4 (netCDF4-python dependency)
-wgetretry ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.0.tar.gz
-tar -xf netcdf-4.4.0.tar.gz
-cd netcdf-4.4.0
+wgetretry ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz
+tar -xf netcdf-4.3.3.1.tar.gz
+cd netcdf-4.3.3.1
 ./configure --enable-netcdf-4 --enable-dap --enable-shared --prefix=$HOME
 make -j4
 make install
 cd $HOME
-rm -rf netcdf-4.4.0*
+rm -rf netcdf-4.3.3.1*
 
 # Install netCDF4-python
 pip3 install netcdf4

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -74,7 +74,7 @@ tar -xf PyQt-gpl-5.5.1.tar.gz
 cd PyQt-gpl-5.5.1
 python3 configure.py --confirm-license
 make -j4
-make install
+make install DESTDIR=$HOME INSTALL_ROOT=$HOME
 cd $HOME
 rm -rf PyQt-gpl-5.5.1*
 

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -137,7 +137,7 @@ pip3 install -U pandas
 # Install mako (optional dependency for pyopencl)
 pip3 install -U mako
 
-# Install ctags
+# Install ctags (dependency for pyopencl)
 wgetretry http://prdownloads.sourceforge.net/ctags/ctags-5.8.tar.gz
 tar -xf ctags-5.8.tar.gz
 cd ctags-5.8
@@ -182,7 +182,7 @@ patch -f stdpy3/lib/python3.4/site-packages/dot_parser.py \
  class P_AttrList:
 EOF
 
-# Upgrade cmake
+# Upgrade cmake (libgpuarray dependency)
 wgetretry https://cmake.org/files/v3.5/cmake-3.5.1.tar.gz
 tar -xf cmake-3.5.1.tar.gz
 cd cmake-3.5.1
@@ -261,7 +261,7 @@ make install
 cd $HOME
 rm -rf libgpuarray
 
-# Install theano
+# Install theano (development version)
 pip3 install git+https://github.com/Theano/Theano.git
 
 # Configure theano


### PR DESCRIPTION
- use k40
- parallelize all `make` calls 
- upgrade to qt5 (changes was required anyway)
- upgrade pyopencl (requires new ctags and gcc 4.8.2+)
- upgrade libgpuarray (requires new cmake and cuda 6.5+)
- upgrade to cuda 7.0
- upgrade theano, lasange
- upgrade netcdf4

Fixes: #2
