### PR TITLE
add tensorflow module

### DIFF
--- a/dtu-hpc-python3/README.md
+++ b/dtu-hpc-python3/README.md
@@ -10,6 +10,28 @@ Install python and friends on DTUs shared user system. Included is:
 * PyOpenCL (with mako)
 * Theano (with pydot, libgpuarray, cuda 8.0 and cuDNN 5)
 
+### Request workspace
+
+Your homedrive uses NFS (file system) which is bazel compatible (compile tool
+used by tensorflow). To fix this you need to request a `/SCRATCH` directory.
+This is a secondary user directory that lives in either `/SCRATCH`, `/work1` or
+`/work2` and it uses a diffrent file system.
+
+You can send a mail like this:
+
+```
+TO: support@cc.dtu.dk
+FROM: <userid>@dtu.dk
+
+Hi DTU HPC
+
+I would like to request a `/SCRATCH` directory which is necessary for compiling
+tensorflow. During compilation this will use approximatly 2 GB.
+
+Thanks.
+<name> <userid>
+```
+
 ### Run setup script
 
 Type or copy this after connecting with SSH:
@@ -22,6 +44,12 @@ less +F -r setup-python3.log
 rm -f setup-python3.*
 ```
 
+### Known issues
+
+Tensorflow should work with multiple GPUs but currently doesn't on the HPC
+system. To use just one GPU set e.g. `CUDA_VISIBLE_DEVICES=3`. To get a
+list of all available GPUs use `nvidia-smi`.
+
 ### After install and future login
 
 For any future login and after the installation run one of these:
@@ -33,7 +61,7 @@ k40sh
 module load python3
 module load gcc/4.9.2
 module load cuda/8.0
-module load cudnn/v5.0-prod
+module load cudnn/v5.1-prod
 module load qt
 export PYTHONPATH=
 source ~/stdpy3/bin/activate
@@ -54,7 +82,7 @@ You can make this happen automatically for all shell-login, just run:
 
 ```shell
 cat >> .gbarrc <<EOF
-MODULES=python3,gcc/6.2.0,qt,cuda/8.0,cudnn/v5.0-prod
+MODULES=python3,gcc/4.9.2,qt,cuda/8.0,cudnn/v5.1-prod
 EOF
 cat >> .profile <<EOF
 # Setup local python3

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -84,6 +84,11 @@ EOM
 fi
 
 #
+# Start time
+#
+start_time=`date +%s`
+
+#
 # Setup virtual env
 #
 export PYTHONPATH=
@@ -277,7 +282,7 @@ export CUDNN_INSTALL_PATH=$CUDNN_PATH
 export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2"
 
 # configure tensorflow
-yes "" | CC=gcc CXX=g++ ./configure
+yes "" 2>/dev/null | CC=gcc CXX=g++ ./configure
 
 # build tensorflow
 # use --verbose_failures -s for more verboseness
@@ -300,6 +305,12 @@ cd $HOME
 rm -rf tensorflow tensorflow_pkg tensorflow.patch
 
 # DONE
+end_time=`date +%s`
+run_time=$((end_time-start_time))
+
+printf '\nInstall script finished. Took: %dh:%dm:%ds\n' \
+  $(($run_time/3600)) $(($run_time%3600/60)) $(($run_time%60))
+
 cat <<EOF
 ####################################
 ##                                ##

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -22,33 +22,70 @@ function wgetretry {
     wget $1 || wget $1 || wget $1 || wget $1 || wget $1 || wget $1 || wget $1 || wget $1 || wget $1 || wget $1
 }
 
-# Load already installed software
+# Unload already installed software
 module unload gcc
 module unload cuda
 module unload cudnn
-
-module load python3
-module load gcc/6.2.0
-module load cuda/8.0
-module load cudnn/v5.0-prod
-module load qt
-module load boost
 
 # Setup to use gnu compiler and hide warnings
 export CC='gcc -w'
 export CXX='g++ -w'
 
 # Setup cuda path for theano
-export CUDA_PATH='/appl/cuda/8.0'
-export CUDNN_PATH='/appl/cudnn/v5.0-prod'
+export CUDA_VERSION='8.0'
+export CUDNN_VERSION='5.1'
+export CUDA_PATH="/appl/cuda/${CUDA_VERSION}"
+export CUDNN_PATH="/appl/cudnn/v${CUDNN_VERSION}-prod"
+
+# load modules
+module load python3
+module load gcc/4.9.2
+module load cuda/$CUDA_VERSION
+module load cudnn/v$CUDNN_VERSION-prod
+module load qt
+module load boost
 
 # Expand path
 export PATH="$HOME/bin:$PATH"
+export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
 
 # Use HOME directory as base
 cd $HOME
 
+#
+# Find bazel workdir
+#
+export WORKDIR=""
+
+if [ -d "/SCRATCH/$USER" ]; then
+  export WORKDIR="/SCRATCH/$USER"
+fi
+
+if [ -d "/work2/$USER" ]; then
+  export WORKDIR="/work2/$USER"
+fi
+
+if [ -d "/work1/$USER" ]; then
+  export WORKDIR="/work1/$USER"
+fi
+
+if [ -z "$WORKDIR" ]; then
+  error_message=`cat <<EOM
+**COULD NOT INSTALL TENSORFLOW**
+A $USER directory could not be found in /SCRATCH, /work2 or /work1
+most likely you have not registred for a SCRATCH directory. This is
+necessary because bazel (used by tensorflow) doesn\'t work on NFS
+(filesystem).
+EOM
+`
+
+  echo "$error_message"
+  exit 1
+fi
+
+#
 # Setup virtual env
+#
 export PYTHONPATH=
 pyvenv ~/stdpy3 --copies
 source ~/stdpy3/bin/activate
@@ -191,6 +228,76 @@ EOF
 
 # Install lasagne (development version)
 pip3 install git+https://github.com/Lasagne/Lasagne.git
+
+#
+# Install TensorFlow
+#
+
+# install bazel (tensorflow dependency)
+wgetretry https://github.com/bazelbuild/bazel/archive/0.3.2.tar.gz
+mv 0.3.2.tar.gz bazel-0.3.2.tar.gz
+tar -xf bazel-0.3.2.tar.gz
+cd bazel-0.3.2
+CC=gcc CXX=g++ ./compile.sh
+cp -f ./output/bazel $HOME/bin/bazel
+cd $HOME
+rm -rf bazel-0.3.2*
+
+# configure bazel
+cat > $HOME/.bazelrc <<EOF
+# --batch: always run in batch mode, since there are some firewall issues.
+# --output_user_root: HOME is NFS (filesystem), this will not work with bazel.
+startup --batch --output_user_root=$WORKDIR/.bazel
+EOF
+
+# install wheel (used for building tensorflow pip package)
+pip3 install -U wheel
+
+# install tensorflow
+git clone https://github.com/tensorflow/tensorflow
+cd tensorflow
+git checkout 5a5a25ea3ebef623e07fb9a46419a9df377a37a5
+
+# apply patch for "could not find as" and "could not find swig"
+curl -L https://raw.githubusercontent.com/AndreasMadsen/my-setup/master/dtu-hpc-python3/tensorflow.patch | git am -
+
+# fix an issue with ldconfig not being in the $PATH
+ln -fs /sbin/ldconfig $HOME/bin/ldconfig
+
+# set configuration parameters
+export PYTHON_BIN_PATH=`which python3`
+export TF_NEED_GCP=0
+export TF_NEED_HDFS=0
+export TF_NEED_CUDA=1
+export GCC_HOST_COMPILER_PATH=`which gcc` # $HOME/gcc
+export TF_CUDA_VERSION=$CUDA_VERSION
+export CUDA_TOOLKIT_PATH=$CUDA_PATH
+export TF_CUDNN_VERSION=`echo $CUDNN_VERSION | head -c 1`
+export CUDNN_INSTALL_PATH=$CUDNN_PATH
+export TF_CUDA_COMPUTE_CAPABILITIES="3.5,5.2"
+
+# configure tensorflow
+yes "" | CC=gcc CXX=g++ ./configure
+
+# build tensorflow
+# use --verbose_failures -s for more verboseness
+CC=gcc CXX=g++ bazel build --copt="-w" \
+--ignore_unsupported_sandboxing --spawn_strategy=standalone \
+-c opt --config=cuda //tensorflow/tools/pip_package:build_pip_package
+
+# build pip package
+./bazel-bin/tensorflow/tools/pip_package/build_pip_package $HOME/tensorflow_pkg
+
+# install tensorflow
+# note that the same will change depending on the version
+pip3 install -U $HOME/tensorflow_pkg/tensorflow-0.11.0rc0-py3-none-any.whl
+
+# cleanup bazel build files
+bazel clean --expunge
+
+# cleanup tensorflow
+cd $HOME
+rm -rf tensorflow tensorflow_pkg tensorflow.patch
 
 # DONE
 cat <<EOF

--- a/dtu-hpc-python3/tensorflow.patch
+++ b/dtu-hpc-python3/tensorflow.patch
@@ -1,0 +1,55 @@
+From 9f53fa2968dacfac398239987adbfc4ddf2305e9 Mon Sep 17 00:00:00 2001
+From: Andreas Madsen <amwebdk@gmai.com>
+Date: Fri, 21 Oct 2016 14:34:48 +0200
+Subject: [PATCH] hpc hack
+
+---
+ tensorflow/python/BUILD                                           | 1 -
+ .../crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl   | 8 ++++++--
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/tensorflow/python/BUILD b/tensorflow/python/BUILD
+index e3313b4..7a2e297 100644
+--- a/tensorflow/python/BUILD
++++ b/tensorflow/python/BUILD
+@@ -1930,7 +1930,6 @@ py_library(
+ # Just used by tests.
+ tf_cuda_library(
+     name = "construction_fails_op",
+-    testonly = 1,
+     srcs = ["client/test_construction_fails_op.cc"],
+     deps = [
+         "//tensorflow/core",
+diff --git a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+index d3bb93c..aad2a1a 100755
+--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
++++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+@@ -48,11 +48,15 @@ import pipes
+ # Template values set by cuda_autoconf.
+ CPU_COMPILER = ('%{cpu_compiler}')
+ GCC_HOST_COMPILER_PATH = ('%{gcc_host_compiler_path}')
++BINTOOLS_PATH = ('/appl/binutils/2.25.1/bin')
+ 
+ CURRENT_DIR = os.path.dirname(sys.argv[0])
+ NVCC_PATH = CURRENT_DIR + '/../../../cuda/bin/nvcc'
+ LLVM_HOST_COMPILER_PATH = ('/usr/bin/gcc')
+-PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
++PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH) + ':' + os.path.dirname(BINTOOLS_PATH)
++
++if 'PATH' in os.environ:
++  PREFIX_DIR = os.environ['PATH']
+ 
+ def Log(s):
+   print('gpus/crosstool: {0}'.format(s))
+@@ -244,7 +248,7 @@ def main():
+   cpu_compiler_flags = [flag for flag in sys.argv[1:]
+                              if not flag.startswith(('--cuda_log'))]
+ 
+-  return subprocess.call([CPU_COMPILER] + cpu_compiler_flags)
++  return subprocess.call([CPU_COMPILER] + cpu_compiler_flags, env=os.environ)
+ 
+ if __name__ == '__main__':
+   sys.exit(main())
+-- 
+2.7.4
+


### PR DESCRIPTION
current issues:
- [x] home directory is NFS, one need to register for a SCRATCH directory. - no fix, but instructions are in readme and the script automatically detects if the SCRATCH directory exists.
- [x] cuDNN module is too old (manual registration and download is required) - cuDNN has been updated
- [x] bazel can't find `swig` (PR: https://github.com/tensorflow/tensorflow/pull/4983) - new tensorflow release builds swig internally.
- [x] bazel can't find `as` (issue: https://github.com/bazelbuild/bazel/issues/1713) - `.patch` file "fixes" this
- [x] HPC drivers too old for CUDA 8.0 - drivers have been updated
- [x] recalibrate wall time estimate
