### PR TITLE
python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A template for LaTeX I have been continuously developing over a few years.
 THE DTU HPC system have quite a lot of legacy. This script updates and install
 the useful stuff.
 
-## [DTU HPC – Python 3.5](dtu-hpc-python3)
+## [DTU HPC – Python 3.6](dtu-hpc-python3)
 
 The Danish Technical University (DTU) have a supercomputer
 (see http://www.cc.dtu.dk/). I use this quite extensively for heavy computation
@@ -37,4 +37,4 @@ an automated setup script for python.
 ## [DTU HPC – Python 2.7](dtu-hpc-python2)
 
 Similar to [DTU HPC – Python 3.5](dtu-hpc-python3) but for python 2.7. I
-no longer maintain this and suggest you use python 3.4.
+no longer maintain this and suggest you use python 3.6.

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ an automated setup script for python.
 
 ## [DTU HPC – Python 2.7](dtu-hpc-python2)
 
-Similar to [DTU HPC – Python 3.5](dtu-hpc-python3) but for python 2.7. I
+Similar to [DTU HPC – Python 3.6](dtu-hpc-python3) but for python 2.7. I
 no longer maintain this and suggest you use python 3.6.

--- a/dtu-hpc-python3/README.md
+++ b/dtu-hpc-python3/README.md
@@ -1,4 +1,4 @@
-# DTU HPC – Python 3.5
+# DTU HPC – Python 3.6
 
 Install python and friends on DTUs shared user system. Included is:
 

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -61,7 +61,7 @@ start_time=`date +%s`
 # Setup virtual env
 #
 export PYTHONPATH=
-pyvenv ~/stdpy3 --copies
+python3 -m venv ~/stdpy3 --copies
 source ~/stdpy3/bin/activate
 
 #

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -273,7 +273,7 @@ CC=gcc CXX=g++ bazel build --copt="-w" \
 
 # install tensorflow
 # note that the same will change depending on the version
-pip3 install -U $HOME/tensorflow_pkg/tensorflow-0.12.1-cp35-cp35m-linux_x86_64.whl
+pip3 install -U $HOME/tensorflow_pkg/tensorflow-0.12.1-cp36-cp36m-linux_x86_64.whl
 
 # cleanup bazel build files
 bazel clean --expunge

--- a/dtu-hpc-python3/setup-python3.sh
+++ b/dtu-hpc-python3/setup-python3.sh
@@ -140,10 +140,10 @@ rm -rf pyopencl-2016.2*
 pip3 install https://bitbucket.org/prologic/pydot/get/ac76697320d6.zip
 pip3 uninstall -y pyparsing
 pip3 install -U pyparsing==2.0.6
-patch -f stdpy3/lib/python3.5/site-packages/dot_parser.py \
+patch -f stdpy3/lib/python3.6/site-packages/dot_parser.py \
 <<EOF
---- a/stdpy3/lib/python3.5/site-packages/dot_parser.py
-+++ b/stdpy3/lib/python3.5/site-packages/dot_parser.py
+--- a/stdpy3/lib/python3.6/site-packages/dot_parser.py
++++ b/stdpy3/lib/python3.6/site-packages/dot_parser.py
 @@ -25,8 +25,9 @@
  from pyparsing import ( nestedExpr, Literal, CaselessLiteral, Word, Upcase, OneOrMore, ZeroOrMore,
      Forward, NotAny, delimitedList, oneOf, Group, Optional, Combine, alphas, nums,


### PR DESCRIPTION
* [fix] python 3.6 pyenv is deprecated, use venv